### PR TITLE
Implement read_committed_no_write and read_committed_with_write

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ Follow these steps if you'd like to use the latest version built from source.
 ## Isolation Levels
 FoundationDB provides serializable isolation under a specific set of [constraints](https://apple.github.io/foundationdb/known-limitations.html#current-limitations). Namely transactions will fail if they take longer than 5 seconds or read/write more than 10,000,000 bytes. This adapter allows the user to relax the how JanusGraph uses FoundationDB transactions and to spread a single JanusGraph transaction over more than one FoundationDB transaction. `read_committed_no_write` allows reads to be spread across more than one transasction, but will fail any writes that are attempted outside of the first transaction period. `read_committed_with_write` allows reads and writes to extend over more than one single transaction. If this option is selected, invariants may be broken and the system will behave similarily to an eventually consistent system.
 
-* **`SERIALIZABLE`** (current state: implemented)
+* **`SERIALIZABLE`** (current state: implemented, used for some tests)
 
     This isolation level aims to provide strict serializability of transactions and thereby deliver FoundationDB's full ACID support to JanusGraph.
 
-* **`READ_COMMITTED_NO_WRITE`** (current state: partially implemented)
+* **`READ_COMMITTED_NO_WRITE`** (current state: implemented, used for most tests)
 
     This allows read accesses which happen within the scope of the same JanusGraph transaction to spread over multiple FoundationDB transactions. **This can cause inconsistencies within the read data**. In order to avoid inconsistent states of the stored data, all writes that are attempted outside the first transaction period will cause the JanusGrpah transaction to fail.
 
-* **`READ_COMMITTED_WITH_WRITE`** (current state: not implemented)
+* **`READ_COMMITTED_WITH_WRITE`** (current state: implemented)
 
     This allows both read and write accesses which happen within the scope of the same JanusGraph transaction to spread over multiple FoundationDB transactions. **This can cause an inconsistent state of the database**. It is not recommended to use this setting in multi threaded or multi user environments.

--- a/src/main/java/com/experoinc/janusgraph/diskstorage/foundationdb/FoundationDBTx.java
+++ b/src/main/java/com/experoinc/janusgraph/diskstorage/foundationdb/FoundationDBTx.java
@@ -56,47 +56,7 @@ public class FoundationDBTx extends AbstractStoreTransaction {
         tx = t;
         this.db = db;
         this.isolationLevel = isolationLevel;
-
-        switch (isolationLevel) {
-        case SERIALIZABLE:
-            this.maxRuns = 1;
-            break;
-        case READ_COMMITTED_NO_WRITE:
-        case READ_COMMITTED_WITH_WRITE:
-            this.maxRuns = maxRuns;
-        }
-    }
-
-    public synchronized void restart() throws FoundationDBTxException {
-        txCtr.incrementAndGet();
-        if (tx == null) {
-            return;
-        }
-
-        try {
-            tx.cancel();
-        } catch (IllegalStateException ignored) {
-        } finally {
-            tx.close();
-        }
-
-        if (isolationLevel == IsolationLevel.SERIALIZABLE && hasCompletedReadOperation) {
-            // only retry this transaction if it has not exposed any data yet
-            throw new FoundationDBTxException(FoundationDBTxException.TIMEOUT);
-        }
-
-        tx = db.createTransaction();
-
-        /*
-         * Reapply mutations but do not clear them out just in case this transaction also
-         * times out and they need to be reapplied.
-         *
-         * @todo Note that at this point, the large transaction case (tx exceeds 10,000,000 bytes)
-         * is not handled.
-         */
-        inserts.forEach(insert -> { tx.set(insert.getKey(), insert.getValue()); });
-
-        deletions.forEach(delete -> { tx.clear(delete); });
+        this.maxRuns = maxRuns;
     }
 
     @Override
@@ -124,10 +84,50 @@ public class FoundationDBTx extends AbstractStoreTransaction {
         }
     }
 
+    private synchronized boolean isCommitAllowed() {
+        if (txCtr.get() == 0) {
+            // committing the first transaction period is always allowed
+            return true;
+        }
+
+        switch (isolationLevel) {
+        case SERIALIZABLE:
+            return !hasCompletedReadOperation;
+        case READ_COMMITTED_NO_WRITE:
+            // retries are allowed as long as no data was read or if there are no writes to perform
+            return (inserts.isEmpty() && deletions.isEmpty()) || !hasCompletedReadOperation;
+        case READ_COMMITTED_WITH_WRITE:
+            return true;
+        default:
+            // default case: should not occur
+            return false;
+        }
+    }
+
+    private synchronized boolean isRestartAllowed() {
+        switch (isolationLevel) {
+        case SERIALIZABLE:
+            // only retry this transaction if it has not exposed any data yet
+            return !hasCompletedReadOperation;
+        case READ_COMMITTED_NO_WRITE:
+            return true;
+        case READ_COMMITTED_WITH_WRITE:
+            return true;
+        default:
+            // default case: should not occur
+            return false;
+        }
+    }
+
     @Override
     public synchronized void commit() throws BackendException {
         boolean failing = true;
+
         for (int i = 0; i < maxRuns; i++) {
+            if (!isCommitAllowed()) {
+                break;
+            }
+
             super.commit();
 
             if (tx == null) {
@@ -136,7 +136,7 @@ public class FoundationDBTx extends AbstractStoreTransaction {
 
             if (log.isTraceEnabled()) {
                 log.trace("{} committed", this.toString(),
-                          new FoundationDBTx.TransactionClosed(this.toString()));
+                        new FoundationDBTx.TransactionClosed(this.toString()));
             }
 
             try {
@@ -162,6 +162,33 @@ public class FoundationDBTx extends AbstractStoreTransaction {
         }
     }
 
+    public synchronized void restart() {
+        if (!isRestartAllowed() || tx == null) {
+            return;
+        }
+
+        txCtr.incrementAndGet();
+
+        try {
+            tx.cancel();
+        } catch (IllegalStateException ignored) {
+        } finally {
+            tx.close();
+        }
+
+        tx = db.createTransaction();
+
+        /*
+         * Reapply mutations but do not clear them out just in case this transaction also
+         * times out and they need to be reapplied.
+         *
+         * @todo Note that at this point, the large transaction case (tx exceeds 10,000,000 bytes)
+         * is not handled.
+         */
+        inserts.forEach(insert -> { tx.set(insert.getKey(), insert.getValue()); });
+        deletions.forEach(delete -> { tx.clear(delete); });
+    }
+
     @Override
     public String toString() {
         return getClass().getSimpleName() + (null == tx ? "nulltx" : tx.toString());
@@ -180,7 +207,7 @@ public class FoundationDBTx extends AbstractStoreTransaction {
      * @throws FoundationDBTxException If the read operation can not be completed.
      */
     public byte[] get(final byte[] key) throws FoundationDBTxException {
-        byte[] result = waitForFuture(readWithRetriesAsync(readTx -> readTx.get(key)));
+        byte[] result = await(readWithRetriesAsync(readTx -> readTx.get(key)));
 
         synchronized (this) {
             hasCompletedReadOperation = true;
@@ -197,7 +224,7 @@ public class FoundationDBTx extends AbstractStoreTransaction {
      */
     public List<KeyValue> getRange(final FoundationDBRangeQuery query)
         throws FoundationDBTxException {
-        List<KeyValue> result = waitForFuture(
+        List<KeyValue> result = await(
             readWithRetriesAsync(readTx
                                  -> readTx
                                         .getRange(query.getStartKeySelector(),
@@ -231,7 +258,7 @@ public class FoundationDBTx extends AbstractStoreTransaction {
 
         Map<KVQuery, List<KeyValue>> resultMap = new ConcurrentHashMap<>();
         for (Entry<KVQuery, CompletableFuture<List<KeyValue>>> entry : futureMap.entrySet()) {
-            resultMap.put(entry.getKey(), waitForFuture(entry.getValue()));
+            resultMap.put(entry.getKey(), await(entry.getValue()));
         }
 
         synchronized (this) {
@@ -271,7 +298,7 @@ public class FoundationDBTx extends AbstractStoreTransaction {
      * @return The future's result if completion was successful.
      * @throws FoundationDBTxException If the future completed exceptionally.
      */
-    private <T> T waitForFuture(CompletableFuture<T> future) throws FoundationDBTxException {
+    private <T> T await(CompletableFuture<T> future) throws FoundationDBTxException {
         try {
             return future.join();
         } catch (CompletionException cex) {
@@ -286,6 +313,7 @@ public class FoundationDBTx extends AbstractStoreTransaction {
                     throw new FoundationDBTxException(eex);
                 }
             } catch (InterruptedException | IllegalStateException e) {
+                e.printStackTrace();
                 throw new FoundationDBTxException(FoundationDBTxException.INTERRUPTED, e);
             } catch (Throwable impossible) {
                 throw new AssertionError(impossible);
@@ -312,11 +340,7 @@ public class FoundationDBTx extends AbstractStoreTransaction {
         for (int i = 1; i < maxRuns; ++i) {
             future = future.exceptionally(th -> {
                 if (txCtr.get() == startTxId[0]) {
-                    try {
-                        this.restart();
-                    } catch (FoundationDBTxException fdbtex) {
-                        throw new CompletionException(fdbtex);
-                    }
+                    this.restart();
                 }
                 startTxId[0] = txCtr.get();
                 try {

--- a/src/test/java/com/experoinc/janusgraph/diskstorage/foundationdb/FoundationDBFixedLengthKCVSTest.java
+++ b/src/test/java/com/experoinc/janusgraph/diskstorage/foundationdb/FoundationDBFixedLengthKCVSTest.java
@@ -43,13 +43,11 @@ public class FoundationDBFixedLengthKCVSTest extends KeyColumnValueStoreTest {
     @Disabled
     @Override
     public void testConcurrentGetSlice() {
-
     }
 
     @Test
     @Disabled
     @Override
     public void testConcurrentGetSliceAndMutate() {
-
     }
 }

--- a/src/test/java/com/experoinc/janusgraph/graphdb/foundationdb/FoundationDBGraphTest.java
+++ b/src/test/java/com/experoinc/janusgraph/graphdb/foundationdb/FoundationDBGraphTest.java
@@ -25,6 +25,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.janusgraph.TestCategory;
 import org.janusgraph.core.JanusGraphException;
 import org.janusgraph.core.JanusGraphFactory;
 import org.janusgraph.diskstorage.BackendException;
@@ -32,6 +33,7 @@ import org.janusgraph.diskstorage.configuration.ConfigOption;
 import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
 import org.janusgraph.graphdb.JanusGraphTest;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,18 +46,17 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers
 public class FoundationDBGraphTest extends JanusGraphTest {
 
-    @Container
-    public static final FoundationDBContainer fdbContainer = new FoundationDBContainer();
+    @Container public static final FoundationDBContainer fdbContainer = new FoundationDBContainer();
 
-    private static final Logger log =
-            LoggerFactory.getLogger(FoundationDBGraphTest.class);
+    private static final Logger log = LoggerFactory.getLogger(FoundationDBGraphTest.class);
 
     private List<String> needSerializable = new ArrayList<>(
         Arrays.asList("testConsistencyEnforcement()", "testConcurrentConsistencyEnforcement()"));
 
     @Override
     public WriteConfiguration getConfiguration() {
-        ModifiableConfiguration modifiableConfiguration = fdbContainer.getFoundationDBConfiguration();
+        ModifiableConfiguration modifiableConfiguration =
+            fdbContainer.getFoundationDBConfiguration();
         String methodName = this.testInfo.getDisplayName();
         if (needSerializable.contains(methodName)) {
             IsolationLevel iso = IsolationLevel.SERIALIZABLE;
@@ -64,9 +65,12 @@ public class FoundationDBGraphTest extends JanusGraphTest {
         } else {
             IsolationLevel iso = null;
             if (modifiableConfiguration.has(FoundationDBConfigOptions.ISOLATION_LEVEL)) {
-                iso = ConfigOption.getEnumValue(modifiableConfiguration.get(FoundationDBConfigOptions.ISOLATION_LEVEL),IsolationLevel.class);
+                iso = ConfigOption.getEnumValue(
+                    modifiableConfiguration.get(FoundationDBConfigOptions.ISOLATION_LEVEL),
+                    IsolationLevel.class);
             }
-            log.debug("Using isolation level {} (null means adapter default) for test method {}", iso, methodName);
+            log.debug("Using isolation level {} (null means adapter default) for test method {}",
+                      iso, methodName);
         }
         return modifiableConfiguration.getConfiguration();
     }
@@ -85,17 +89,27 @@ public class FoundationDBGraphTest extends JanusGraphTest {
         super.testConcurrentConsistencyEnforcement();
     }
 
+    @Tag(TestCategory.BRITTLE_TESTS)
     @Test
     @Override
     public void testIndexShouldRegisterWhenWeRemoveAnInstance() throws InterruptedException {
-        // TODO figure out why this test is failing
+        /**
+         * This test outputs expected log message
+         * "INFO: Set status REGISTERED on schema element theIndex with property keys []"
+         * ONLY in debugging mode but not when the test is run automatically
+         */
         super.testIndexShouldRegisterWhenWeRemoveAnInstance();
     }
 
     @Test
     @Override
+    @Tag(TestCategory.BRITTLE_TESTS)
     public void testIndexUpdateSyncWithMultipleInstances() throws InterruptedException {
-        // TODO figure out why this test is failing
+        /**
+         * This test outputs expected log message
+         * "INFO: Set status REGISTERED on schema element theIndex with property keys []"
+         * ONLY in debugging mode but not when the test is run automatically
+         */
         super.testIndexUpdateSyncWithMultipleInstances();
     }
 
@@ -110,7 +124,6 @@ public class FoundationDBGraphTest extends JanusGraphTest {
             graph.addVertex();
             fail();
         } catch (JanusGraphException ignored) {
-
         }
 
         assertTrue(graph.isOpen());

--- a/src/test/java/com/experoinc/janusgraph/graphdb/foundationdb/FoundationDBGraphTest.java
+++ b/src/test/java/com/experoinc/janusgraph/graphdb/foundationdb/FoundationDBGraphTest.java
@@ -22,6 +22,9 @@ import com.experoinc.janusgraph.diskstorage.foundationdb.FoundationDBConfigOptio
 import com.experoinc.janusgraph.diskstorage.foundationdb.FoundationDBTx.IsolationLevel;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.janusgraph.core.JanusGraphException;
 import org.janusgraph.core.JanusGraphFactory;
 import org.janusgraph.diskstorage.BackendException;
@@ -47,11 +50,14 @@ public class FoundationDBGraphTest extends JanusGraphTest {
     private static final Logger log =
             LoggerFactory.getLogger(FoundationDBGraphTest.class);
 
+    private List<String> needSerializable = new ArrayList<>(
+        Arrays.asList("testConsistencyEnforcement()", "testConcurrentConsistencyEnforcement()"));
+
     @Override
     public WriteConfiguration getConfiguration() {
         ModifiableConfiguration modifiableConfiguration = fdbContainer.getFoundationDBConfiguration();
         String methodName = this.testInfo.getDisplayName();
-        if (methodName.equals("testConsistencyEnforcement()") || methodName.equals("testConcurrentConsistencyEnforcement()")) {
+        if (needSerializable.contains(methodName)) {
             IsolationLevel iso = IsolationLevel.SERIALIZABLE;
             log.debug("Forcing isolation level {} for test method {}", iso, methodName);
             modifiableConfiguration.set(FoundationDBConfigOptions.ISOLATION_LEVEL, iso.toString());
@@ -81,8 +87,16 @@ public class FoundationDBGraphTest extends JanusGraphTest {
 
     @Test
     @Override
-    public void testTinkerPopOptimizationStrategies() {
-        super.testTinkerPopOptimizationStrategies();
+    public void testIndexShouldRegisterWhenWeRemoveAnInstance() throws InterruptedException {
+        // TODO figure out why this test is failing
+        super.testIndexShouldRegisterWhenWeRemoveAnInstance();
+    }
+
+    @Test
+    @Override
+    public void testIndexUpdateSyncWithMultipleInstances() throws InterruptedException {
+        // TODO figure out why this test is failing
+        super.testIndexUpdateSyncWithMultipleInstances();
     }
 
     @Test

--- a/src/test/java/com/experoinc/janusgraph/graphdb/foundationdb/FoundationDBOperationCountingTest.java
+++ b/src/test/java/com/experoinc/janusgraph/graphdb/foundationdb/FoundationDBOperationCountingTest.java
@@ -23,6 +23,7 @@ import org.janusgraph.diskstorage.configuration.ConfigOption;
 import org.janusgraph.diskstorage.configuration.ModifiableConfiguration;
 import org.janusgraph.diskstorage.configuration.WriteConfiguration;
 import org.janusgraph.graphdb.JanusGraphOperationCountingTest;
+import org.janusgraph.testutil.FlakyTest;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,6 +72,7 @@ public class FoundationDBOperationCountingTest extends JanusGraphOperationCounti
     }
 
     @Test
+    @FlakyTest
     @Override
     public void testCacheConcurrency() throws InterruptedException {
         // this test's isolation level is set to SERIALIZABLE in getConfiguration


### PR DESCRIPTION
This adds the retry logic for both relaxed isolation levels.

Two tests are still failing with this implementation:
- [ ] `FoundationDBGraphTest.testIndexShouldRegisterWhenWeRemoveAnInstance()`
- [ ] `FoundationDBGraphTest.testIndexUpdateSyncWithMultipleInstances()`

Both test cases were also failing since JanusGraph was updated to v0.5.0